### PR TITLE
marks module as complete

### DIFF
--- a/src/Module/components/ModuleDefault.vue
+++ b/src/Module/components/ModuleDefault.vue
@@ -170,6 +170,17 @@ export default defineComponent({
 
     state.userId = props.userDoc?.data._id;
 
+    // Used for storing completeness of this module for the individual student.
+    // Might be best to store in teamDoc, but we currently only check student's individual program for completeness
+    let index = state.programDoc.value.data.adks.findIndex(function findResearchObj(obj) {
+      return obj.name === 'make';
+    });
+    if (index === -1)
+      index =
+        state.programDoc.value.data.adks.push({
+          name: 'make'
+        }) - 1;
+
     const onFilesAdded = (event: Event) => {
       event.target!.files.forEach((file: File) => {
         const reader = new FileReader();
@@ -211,6 +222,14 @@ export default defineComponent({
       state.images = [];
       state.logInput = '';
       state.logError = '';
+
+      // TODO: get the actual expected minimum log length.
+      if (state.teamAdkData!.logs.length > 3) {
+        state.programDoc.value.update(() => ({
+        isComplete: true,
+        adkIndex: index
+      }))
+      }
     };
 
     const removeMilestone = (id: ObjectId) => {

--- a/src/Module/types.ts
+++ b/src/Module/types.ts
@@ -14,6 +14,6 @@ export interface Image {
 
 export interface MongoDoc {
   data: Record<string, any>;
-  update: () => Promise<any>;
+  update: (shouldMarkAsComplete?:any) => Promise<any>;
   changeStream: any;
 }


### PR DESCRIPTION
I have not been able to test this module, so I'm just taking my best guess as to how we want to evaluate when users have completed it. In this case, I assume that when users have uploaded enough logs via the `logMilestone()` function, we will mark it as complete.  I've left a placeholder amount (100) for now, but that will likely need to be set on a per-program basis.

Important note: users write to a collective `teamDoc` but we currently store the completeness flag in individual program docs (`state.programDoc`) because the main platform `pcv4maxpro` only looks at the the individual doc. It is probably best for the completeness flag to live with the data but that will require significant rework of [this function](https://github.com/PilotCityInc/pcv4maxpro/blob/b458ec33b6f3381eec83ec0319ff8f19627b877b/src/views/Guide/Guide.vue#L249-L250).

# TODO
- [ ] test module (module is incomplete at the time of this PR)
- [ ] bump up npm package version